### PR TITLE
Hotfix/backward python compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["django", "services", "octue", "twined"]
 packages = [{ include = "django_twined" },]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 django = ">=3.0,<4.0"
 channels = ">=3.0,<4.0"
 octue = "0.10.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-twined"
-version = "0.2.0"
+version = "0.2.1"
 description = "A django app to manage octue services"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Library is already fully tested on python 3.8; this hotfix prevents poetry from barfing if installing on python 3.8 (because it checks the version range in pyproject.toml).

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
