### PR TITLE
FEA: Allow easier override of ask() to set service_revision

### DIFF
--- a/django_twined/models/questions.py
+++ b/django_twined/models/questions.py
@@ -92,7 +92,7 @@ class AbstractQuestion(models.Model):
         if save:
             self.save()
 
-        return subscription, push_url
+        return subscription, push_url, service_revision
 
 
 class Question(AbstractQuestion):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-twined"
-version = "0.3.0"
+version = "0.4.0"
 description = "A django app to manage octue services"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"


### PR DESCRIPTION
BREAKING-CHANGE: Question.ask() now returns 3 values, not 2, so invocations and overrides of Question.ask() should account for being returned also a service_revision value

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

# Summary

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
