### PR TITLE
Make registry endpoint CSRF-exempt by default

### DIFF
--- a/.github/workflows/add-issues-to-octue-board.yaml
+++ b/.github/workflows/add-issues-to-octue-board.yaml
@@ -1,0 +1,11 @@
+name: add-issues-to-octue-board
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  add-issues-to-octue-board:
+    uses: octue/.github/.github/workflows/reusable-add-issues-to-octue-board.yaml@main
+    secrets:
+      github-token: ${{ secrets.PROJECT_AUTOMATION_GITHUB_TOKEN_2 }}

--- a/django_twined/urls.py
+++ b/django_twined/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
+from django.views.decorators.csrf import csrf_exempt
 from django_twined.views import service_revision
 
 
 urlpatterns = [
-    path(r"services/<namespace>/<name>", service_revision, name="services"),
+    path(r"services/<namespace>/<name>", csrf_exempt(service_revision), name="services"),
 ]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,6 +50,12 @@ Include the django-twined URLs in your ``your_app/urls.py``:
 
 Using ``python manage.py show_urls`` you can now see the endpoint for registering and getting service revisions appear in your app.
 
+.. warning::
+
+    The registry URLs are CSRF-exempt by default to allow automatic service revision registration from, for example,
+    GitHub Actions. If you don't want this behaviour, you can import the view at ``django_twined.views.service_revision``
+    and use it in your URL patterns as you like.
+
 Run migrations
 --------------
 Then run ``python manage.py migrate django_twined`` to add the models used for managing services, events and questions to your database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-twined"
-version = "0.6.0"
+version = "0.6.1"
 description = "A django app to manage octue services"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"

--- a/tests/test_models/test_service_revisions.py
+++ b/tests/test_models/test_service_revisions.py
@@ -69,10 +69,10 @@ class ServiceRevisionTestCase(TestCase):
             project_name="gargantuan-gibbons",
             namespace="large-gibbons",
             name="gibbon-analyser",
-            tag="latest",
+            tag="1.0.0",
         )
 
-        self.assertEqual(sr.topic, "octue.services.large-gibbons.gibbon-analyser.latest")
+        self.assertEqual(sr.topic, "octue.services.large-gibbons.gibbon-analyser.1-0-0")
 
     def test_create_with_defaults(self):
         """Ensure that default settings are read for creating default entries in the db"""

--- a/tests/test_models/test_service_revisions.py
+++ b/tests/test_models/test_service_revisions.py
@@ -9,16 +9,6 @@ class TestServiceRevisionIsLatestSemanticVersion(TestCase):
     NAMESPACE = "my-org"
     NAME = "my-service"
 
-    def test_revision_with_non_semantic_version_tag_not_found_to_be_latest_version(self):
-        """Test that a service revisions with a tag that isn't a semantic versions is not found to be the latest
-        version.
-        """
-        ServiceRevision.objects.create(namespace=self.NAMESPACE, name=self.NAME, tag="0.1.0")
-        ServiceRevision.objects.create(namespace=self.NAMESPACE, name=self.NAME, tag="2.1.0", is_default=True)
-
-        new_revision = ServiceRevision(namespace=self.NAMESPACE, name=self.NAME, tag="hello")
-        self.assertFalse(service_revision_is_latest_semantic_version(new_revision))
-
     def test_revision_with_larger_semantic_version_found_to_be_latest_version(self):
         """Test that a service revision with a semantic version that is naturally/semantically, but not alphabetically,
         larger than the version of the default revision is not found to be the latest version.

--- a/tests/test_models/test_service_usage_events.py
+++ b/tests/test_models/test_service_usage_events.py
@@ -39,7 +39,7 @@ class ServiceUsageEventTestCase(TestCase):
             mock.return_value = ("subscription", "push_url")
 
             sr = ServiceRevision.objects.create(
-                project_name="gargantuan-gibbons", namespace="large-gibbons", name="gibbon-analyser", tag="latest"
+                project_name="gargantuan-gibbons", namespace="large-gibbons", name="gibbon-analyser", tag="1.0.0"
             )
 
             q = QuestionWithValuesDatabaseStorage.objects.create(service_revision=sr)
@@ -54,7 +54,7 @@ class ServiceUsageEventTestCase(TestCase):
         self.assertTrue(
             push_url.startswith(f"https://my-server.com/gcp/events/{QUESTION_RESPONSE_UPDATED}/{str(q.id)}")
         )
-        self.assertTrue("sruid=large-gibbons%2Fgibbon-analyser%3Alatest" in push_url)
+        self.assertTrue("sruid=large-gibbons%2Fgibbon-analyser%3A1.0.0" in push_url)
         self.assertTrue(f"srid={str(sr.id)}" in push_url)
 
         local_url = push_url.replace("https://my-server.com", "")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,7 +17,7 @@ class TestServiceRevision(TestCase):
         """Test that an error response is returned if trying to get a non-existent service."""
         response = self.client.get(
             reverse("services", kwargs={"name": "non-existent", "namespace": "service"}),
-            data={"revision_tag": "latest"},
+            data={"revision_tag": "1.3.9"},
         )
 
         self.assertEqual(response.json(), {"error": "Service revision not found."})


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#55](https://github.com/octue/django-twined/pull/55))

### Fixes
- Make service revision registry endpoint CSRF-exempt by default

### Operations
- Add workflow to add issues to Octue project

### Testing
- Remove reference to `latest` tag
- Remove outdated test

<!--- END AUTOGENERATED NOTES --->