### PR TITLE
Allow setting of `is_default` during service registration

### DIFF
--- a/django_twined/views.py
+++ b/django_twined/views.py
@@ -55,7 +55,9 @@ def service_revision(request, namespace, name):
 
         service_revision = ServiceRevision(namespace=namespace, name=name, tag=body["revision_tag"])
 
-        if SERVICE_REVISION_IS_DEFAULT_CALLBACK is not None:
+        if "is_default" in body:
+            service_revision.is_default = body["is_default"]
+        elif SERVICE_REVISION_IS_DEFAULT_CALLBACK is not None:
             service_revision.is_default = SERVICE_REVISION_IS_DEFAULT_CALLBACK(service_revision)
 
         service_revision.save()

--- a/docs/source/service_revisions.rst
+++ b/docs/source/service_revisions.rst
@@ -32,6 +32,11 @@ be:
         json={"revision_tag": "1.2.9"},
     )
 
+.. tip::
+
+    To override the registry deciding if the service revision being registered should be set as the default (see below),
+    add the ``"is_default"`` key to the request body and set it to either ``True`` or ``False``.
+
 Getting the default service revision
 ====================================
 You can request the default service revision by not specifying a revision tag. By default, the service revision with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-twined"
-version = "0.6.1"
+version = "0.6.2"
 description = "A django app to manage octue services"
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#56](https://github.com/octue/django-twined/pull/56))

### Enhancements
- Allow setting of `is_default` during service registration

### Other
- Update docs

<!--- END AUTOGENERATED NOTES --->