### PR TITLE
Reinstate fieldsets for admin and make test server boot

### DIFF
--- a/django_twined/admin/admin.py
+++ b/django_twined/admin/admin.py
@@ -8,6 +8,14 @@ from django_twined.models import Question, ServiceRevision, ServiceUsageEvent
 from jsoneditor.forms import JSONEditor
 from octue.log_handlers import LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP, create_octue_formatter
 
+from .fieldsets import (
+    question_basic_fieldset,
+    question_delivery_ack_fieldset,
+    question_exceptions_fieldset,
+    question_log_records_fieldset,
+    question_monitor_messages_fieldset,
+    question_result_fieldset,
+)
 from .mixins import CreatableFieldsMixin
 
 
@@ -48,25 +56,14 @@ class QuestionAdmin(admin.ModelAdmin):
     )
 
     fieldsets = (
-        (
-            None,
-            {
-                "fields": (
-                    "id",
-                    "status",
-                    "service_revision",
-                    "asked",
-                    "answered",
-                    "latest_heartbeat",
-                )
-            },
-        ),
-        ("Inputs", {"classes": ("collapse",), "fields": ("input_values",)}),
-        ("Delivery Acknowledgement", {"classes": ("collapse",), "fields": ("delivery_acknowledgement",)}),
-        ("Log Records", {"classes": ("collapse",), "fields": ("log_records",)}),
-        ("Monitor Messages", {"classes": ("collapse",), "fields": ("monitor_messages",)}),
-        ("Result", {"classes": ("collapse",), "fields": ("result",)}),
-        ("Exceptions", {"classes": ("collapse",), "fields": ("exceptions",)}),
+        question_basic_fieldset,
+        # question_db_input_values_fieldset,
+        # question_db_output_values_fieldset,
+        question_delivery_ack_fieldset,
+        question_log_records_fieldset,
+        question_monitor_messages_fieldset,
+        question_result_fieldset,
+        question_exceptions_fieldset,
     )
 
     # @staticmethod

--- a/django_twined/admin/admin.py
+++ b/django_twined/admin/admin.py
@@ -131,15 +131,6 @@ class QuestionAdmin(admin.ModelAdmin):
         """
         return obj.result.data
 
-    @staticmethod
-    def duration(obj):
-        """Show the time it took to answer the question in seconds.
-
-        :return int|None:
-        """
-        if obj.answered and obj.asked:
-            return (obj.answered - obj.asked).seconds
-
     def ask_question(self, obj):
         """Override this to ask a question using an async task queue or other method. This will ask the question directly."""
         obj.ask()

--- a/django_twined/admin/admin.py
+++ b/django_twined/admin/admin.py
@@ -135,9 +135,10 @@ class QuestionAdmin(admin.ModelAdmin):
     def duration(obj):
         """Show the time it took to answer the question in seconds.
 
-        :return int:
+        :return int|None:
         """
-        return (obj.answered - obj.asked).seconds
+        if obj.answered and obj.asked:
+            return (obj.answered - obj.asked).seconds
 
     def ask_question(self, obj):
         """Override this to ask a question using an async task queue or other method. This will ask the question directly."""

--- a/django_twined/admin/admin.py
+++ b/django_twined/admin/admin.py
@@ -134,6 +134,14 @@ class QuestionAdmin(admin.ModelAdmin):
         """
         return obj.result.data
 
+    @staticmethod
+    def duration(obj):
+        """Show the time it took to answer the question in seconds.
+
+        :return int:
+        """
+        return (obj.answered - obj.asked).seconds
+
     def ask_question(self, obj):
         """Override this to ask a question using an async task queue or other method. This will ask the question directly."""
         obj.ask()

--- a/django_twined/admin/fieldsets.py
+++ b/django_twined/admin/fieldsets.py
@@ -1,0 +1,25 @@
+question_basic_fieldset = (
+    None,
+    {
+        "fields": (
+            "id",
+            "status",
+            "service_revision",
+            "asked",
+            "answered",
+            "latest_heartbeat",
+        )
+    },
+)
+
+question_db_input_values_fieldset = ("Input Values", {"classes": ("collapse",), "fields": ("input_values",)})
+question_db_output_values_fieldset = ("Output Values", {"classes": ("collapse",), "fields": ("output_values",)})
+
+question_delivery_ack_fieldset = (
+    "Delivery Acknowledgement",
+    {"classes": ("collapse",), "fields": ("delivery_acknowledgement",)},
+)
+question_log_records_fieldset = ("Log Records", {"classes": ("collapse",), "fields": ("log_records",)})
+question_monitor_messages_fieldset = ("Monitor Messages", {"classes": ("collapse",), "fields": ("monitor_messages",)})
+question_result_fieldset = ("Result", {"classes": ("collapse",), "fields": ("result",)})
+question_exceptions_fieldset = ("Exceptions", {"classes": ("collapse",), "fields": ("exceptions",)})

--- a/django_twined/admin/fieldsets.py
+++ b/django_twined/admin/fieldsets.py
@@ -8,6 +8,7 @@ question_basic_fieldset = (
             "asked",
             "answered",
             "latest_heartbeat",
+            "duration",
         )
     },
 )

--- a/django_twined/models/questions.py
+++ b/django_twined/models/questions.py
@@ -60,6 +60,15 @@ class AbstractQuestion(models.Model):
         """
         return STATUS_MESSAGE_MAP[self.status]
 
+    @property
+    def duration(self):
+        """Show the time it took to answer the question in seconds.
+
+        :return int|None:
+        """
+        if self.answered and self.asked:
+            return (self.answered - self.asked).seconds
+
     def get_duplicate(self, save=True):
         """Duplicate the question instance and optionally save to the database"""
         kwargs = {}

--- a/django_twined/signals/receivers.py
+++ b/django_twined/signals/receivers.py
@@ -55,7 +55,7 @@ def receive_event(sender, event_kind, event_reference, event_payload, event_para
         if event_kind == "delivery_acknowledgement":
             delivery_acknowledgement_received.send(sender=ServiceUsageEvent, service_usage_event=sue)
 
-        if event_kind == "exception":
+        elif event_kind == "exception":
             exception_received.send(sender=ServiceUsageEvent, service_usage_event=sue)
 
         elif event_kind == "heartbeat":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
 repository = "https://github.com/octue/django-twined"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-twined"
-version = "0.7.1"
+version = "0.7.2"
 description = "A django app to manage octue services"
 authors = ["Tom Clark <tom@octue.com>", "Marcus Lugg <marcus@octue.com>"]
 license = "MIT"

--- a/tests/server/asgi.py
+++ b/tests/server/asgi.py
@@ -1,5 +1,4 @@
-import django_twined.routing
-from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.routing import ProtocolTypeRouter
 from django.core.asgi import get_asgi_application
 
 
@@ -7,6 +6,4 @@ from django.core.asgi import get_asgi_application
 #               The main django application which you're writing an app for will need to set up something similar
 
 
-application = ProtocolTypeRouter(
-    {"http": get_asgi_application(), "websocket": URLRouter(django_twined.routing.websocket_urlpatterns)}
-)
+application = ProtocolTypeRouter({"http": get_asgi_application()})


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#70](https://github.com/octue/django-twined/pull/70))

### Enhancements
- Add `duration` property to `AbstractQuestion` model and show it in `QuestionAdmin`

### Fixes
- Reinstate fieldsets for admin and make test server boot
- Fix `elif` statement in event handler


<!--- END AUTOGENERATED NOTES --->