### PR TITLE
Fix publishing on CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
           version: "0.7.7" # Match the version in the devcontainer stack - see https://github.com/windpioneers/gdal-python/releases
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.13
 
       - name: Install the project
         run: uv sync --locked --all-extras --dev
@@ -54,11 +54,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install poetry
-        uses: snok/install-poetry@v1.4.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Build a binary wheel and a source tarball
-        run: poetry build
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          # Installs the latest version compatible with the requires-python field
+          python-version-file: "pyproject.toml"
+
+      - name: Install the project
+        run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ license = "MIT"
 name = "django-twined"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.13"
+version = "0.8.14"
 
 [project.urls]
 Changelog = "https://github.com/octue/django-twined/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -489,7 +489,7 @@ wheels = [
 
 [[package]]
 name = "django-twined"
-version = "0.8.13"
+version = "0.8.14"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#90](https://github.com/octue/django-twined/pull/90))

### Operations
- Fix publishing on CI

<!--- END AUTOGENERATED NOTES --->