### PR TITLE
Widen django-gcp dependencies fully t avoid rapid development loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
   "django>=3.0,<5.1",
   "octue>=0.52.0,<0.64.0",
-  "django-gcp>=0.11.5,<0.21",
+  "django-gcp>=0.11.5,<1",
   "django-jsoneditor>=0.2.2,<0.3",
   "django-model-utils>4.2.0,<6"
 ]
@@ -58,7 +58,7 @@ license = "MIT"
 name = "django-twined"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.8.16"
+version = "0.8.17"
 
 [project.urls]
 Changelog = "https://github.com/octue/django-twined/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -489,7 +489,7 @@ wheels = [
 
 [[package]]
 name = "django-twined"
-version = "0.8.16"
+version = "0.8.17"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -526,7 +526,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=3.0,<5.1" },
-    { name = "django-gcp", specifier = ">=0.11.5,<0.21" },
+    { name = "django-gcp", specifier = ">=0.11.5,<1" },
     { name = "django-jsoneditor", specifier = ">=0.2.2,<0.3" },
     { name = "django-model-utils", specifier = ">4.2.0,<6" },
     { name = "octue", specifier = ">=0.52.0,<0.64.0" },


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#95](https://github.com/octue/django-twined/pull/95))

### Fixes
- Neverending loop of widening django-gcp

<!--- END AUTOGENERATED NOTES --->